### PR TITLE
Add CSV report export

### DIFF
--- a/src/lib/utils/exporters.test.ts
+++ b/src/lib/utils/exporters.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { RankedIssue } from '../types';
+import { exportToCSV } from './exporters';
+
+function issue(overrides: Partial<RankedIssue> = {}): RankedIssue {
+  return {
+    number: 42,
+    title: 'Fix CSV, quotes, and newlines',
+    body: null,
+    user: {
+      login: 'octocat',
+      avatar_url: '',
+      html_url: 'https://github.com/octocat',
+    },
+    labels: [],
+    assignees: [],
+    comments_count: 0,
+    created_at: '2026-05-12T00:00:00Z',
+    updated_at: '2026-05-12T00:00:00Z',
+    html_url: 'https://github.com/owner/repo/issues/42',
+    state: 'open',
+    score: 88,
+    analysis: {
+      summary: 'Small CSV export task',
+      status: 'active',
+      progress_estimate: 'not_started',
+      is_actionable_code_change: true,
+      not_mergeable_reason: null,
+      complexity: 2,
+      skills_required: ['TypeScript', 'CSV'],
+      newcomer_friendliness: 4,
+      doability_score: 88,
+      analysis_notes: 'Ready to implement',
+    },
+    ...overrides,
+  };
+}
+
+describe('exportToCSV', () => {
+  it('includes a UTF-8 BOM and CRLF row endings for spreadsheet compatibility', () => {
+    const csv = exportToCSV([issue()]);
+
+    expect(csv.charCodeAt(0)).toBe(0xfeff);
+    expect(csv).toContain('\r\n');
+    expect(csv).not.toContain('\nRank');
+  });
+
+  it('escapes commas, quotes, and newlines in CSV cells', () => {
+    const csv = exportToCSV([
+      issue({
+        title: 'Fix "quoted", multiline\ntitle',
+      }),
+    ]);
+
+    expect(csv).toContain('"Fix ""quoted"", multiline\ntitle"');
+  });
+});

--- a/src/lib/utils/exporters.ts
+++ b/src/lib/utils/exporters.ts
@@ -97,7 +97,7 @@ export function exportToCSV(issues: RankedIssue[]): string {
     ];
   });
 
-  return [headers, ...rows].map((row) => row.map(csvCell).join(',')).join('\n');
+  return `\uFEFF${[headers, ...rows].map((row) => row.map(csvCell).join(',')).join('\r\n')}`;
 }
 
 export function downloadMarkdown(content: string, filename: string): void {
@@ -111,7 +111,8 @@ export function downloadMarkdown(content: string, filename: string): void {
 }
 
 export function downloadCSV(content: string, filename: string): void {
-  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' });
+  const csvContent = content.startsWith('\uFEFF') ? content : `\uFEFF${content}`;
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;

--- a/src/lib/utils/exporters.ts
+++ b/src/lib/utils/exporters.ts
@@ -63,8 +63,55 @@ export function exportToMarkdown(issues: RankedIssue[], repoName: string): strin
   return lines.filter((l) => l !== undefined).join('\n');
 }
 
+function csvCell(value: string | number | null | undefined): string {
+  const text = String(value ?? '');
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+export function exportToCSV(issues: RankedIssue[]): string {
+  const headers = [
+    'Rank',
+    'Issue #',
+    'Title',
+    'Score',
+    'Status',
+    'Complexity',
+    'Newcomer Friendliness',
+    'Skills Required',
+    'URL',
+  ];
+
+  const rows = issues.map((issue, i) => {
+    const analysis = issue.analysis;
+
+    return [
+      i + 1,
+      issue.number,
+      issue.title,
+      issue.score,
+      analysis ? statusLabel(analysis.status) : '',
+      analysis ? complexityLabel(analysis.complexity) : '',
+      analysis ? friendlinessLabel(analysis.newcomer_friendliness) : '',
+      analysis?.skills_required.join(', ') ?? '',
+      issue.html_url,
+    ];
+  });
+
+  return [headers, ...rows].map((row) => row.map(csvCell).join(',')).join('\n');
+}
+
 export function downloadMarkdown(content: string, filename: string): void {
   const blob = new Blob([content], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadCSV(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;

--- a/src/screens/ReportScreen.tsx
+++ b/src/screens/ReportScreen.tsx
@@ -7,9 +7,9 @@ import { useAppStore } from '../store/appStore';
 import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
 import type { RankedIssue } from '../lib/types';
 import { Button } from '../components/ui/Button';
-import { Download, RotateCcw } from 'lucide-react';
+import { Download, FileSpreadsheet, RotateCcw } from 'lucide-react';
 import { parseRepoInput } from '../lib/utils/validators';
-import { exportToMarkdown, downloadMarkdown } from '../lib/utils/exporters';
+import { exportToMarkdown, downloadMarkdown, exportToCSV, downloadCSV } from '../lib/utils/exporters';
 
 export function ReportScreen() {
   const { getRankedIssues, selectedIssueId, selectIssue, searchQuery, setSearchQuery } =
@@ -77,6 +77,14 @@ export function ReportScreen() {
     useAppStore.getState().addLog('Report exported as Markdown.', 'success');
   }, [getRankedIssues, repoInput]);
 
+  const handleExportCSV = useCallback(() => {
+    const ranked = getRankedIssues();
+    const { owner, repo } = parseRepoInput(repoInput);
+    const csv = exportToCSV(ranked);
+    downloadCSV(csv, `isscope-report-${owner}-${repo}.csv`);
+    useAppStore.getState().addLog('Report exported as CSV.', 'success');
+  }, [getRankedIssues, repoInput]);
+
   return (
     <ScreenLayout>
       <div
@@ -95,6 +103,9 @@ export function ReportScreen() {
         <div style={{ display: 'flex', gap: '6px' }}>
           <Button variant="ghost" size="sm" onClick={handleExport} title="Export Markdown report">
             <Download size={13} /> Export
+          </Button>
+          <Button variant="ghost" size="sm" onClick={handleExportCSV} title="Export CSV report">
+            <FileSpreadsheet size={13} /> CSV
           </Button>
           <Button variant="ghost" size="sm" onClick={reset} title="New analysis">
             <RotateCcw size={13} /> New


### PR DESCRIPTION
﻿## Summary
- add CSV report generation with proper escaping for commas, quotes, and newlines
- add a CSV download helper using the `text/csv` MIME type
- add an Export CSV button next to the existing Markdown export action
- improve spreadsheet compatibility by using a UTF-8 BOM and CRLF row endings

Closes #15

## Type of Change
- Feature / enhancement

## Checklist
- [x] CSV export is available from the report screen
- [x] CSV cells escape commas, quotes, and newlines
- [x] CSV output includes UTF-8 BOM and CRLF row endings for spreadsheet compatibility
- [x] Added regression tests for CSV export formatting

## Testing
- `bun x lint-staged`
- `bun run typecheck`
- `bun run lint`
- `bun run test -- --run`
- `bun run build`
- Windows browser smoke test with local Vite app and Chrome
- Downloaded generated CSV and verified: BOM=true, CRLF=true, escaping=true

## Screenshots

Report screen with the CSV export button:

![CSV export report screen](https://raw.githubusercontent.com/eta7osc/isscope/pr-assets/pr-assets/csv-export-report.png)

Sample generated CSV: https://raw.githubusercontent.com/eta7osc/isscope/pr-assets/pr-assets/isscope-report-vee1e-isscope.csv

## AI Disclosure

Yes. I used OpenAI Codex to help inspect the codebase, implement the CSV export change, add regression tests, run local validation, and prepare this PR description. I reviewed the generated code and test output before submitting and take responsibility for the changes.

## Additional Notes

The Windows Bun installer exposed `bun.exe` but not a separate `bunx.exe` shim in this shell. I verified the same hook task with `bun x lint-staged`, and also created a temporary local shim so the repository pre-commit hook invocation of `bunx lint-staged` ran successfully during the follow-up commit.
