### PR TITLE
fix: add localStorage plain text warning for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This project is built using modern web technologies:
 - Fetches issue details and performs AI analysis in parallel for high throughput.
 - Renders issue bodies and comments with full Markdown and HTML image support.
 - Vim-style navigation (j/k, gg, G) and keyboard shortcuts for efficiency.
-- API keys are stored in memory and never sent to a backend server.
+- API keys are stored in plain text in the browser's localStorage and never sent to a backend server. Be aware of this when using shared computers.
 
 ## Local Setup Instructions
 

--- a/src/screens/InputScreen.tsx
+++ b/src/screens/InputScreen.tsx
@@ -533,6 +533,18 @@ export function InputScreen() {
                   >
                     GitHub Token (optional, for higher rate limits)
                   </label>
+                  <div
+                    style={{
+                      fontSize: '11px',
+                      color: '#f59e0b',
+                      marginBottom: '6px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                    }}
+                  >
+                    Stored in plain text in browser localStorage
+                  </div>
                   <div style={{ position: 'relative' }}>
                     <input
                       type="password"
@@ -578,6 +590,18 @@ export function InputScreen() {
                   >
                     OpenRouter API Key (required for analysis)
                   </label>
+                  <div
+                    style={{
+                      fontSize: '11px',
+                      color: '#f59e0b',
+                      marginBottom: '6px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                    }}
+                  >
+                    Stored in plain text in browser localStorage
+                  </div>
                   <div style={{ position: 'relative' }}>
                     <input
                       type="password"


### PR DESCRIPTION
Addresses vee1e/isscope#16

Add visible warning below each API key input field explaining that keys are stored in plain text in localStorage. Also update README to reflect this.