### PR TITLE
Fix: make API key persistence optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This project is built using modern web technologies:
 - Fetches issue details and performs AI analysis in parallel for high throughput.
 - Renders issue bodies and comments with full Markdown and HTML image support.
 - Vim-style navigation (j/k, gg, G) and keyboard shortcuts for efficiency.
-- API keys are stored in memory and never sent to a backend server.
+- API keys are stored only in memory by default and are never sent to a backend server. Users can optionally enable local browser storage for persistence.
 
 ## Local Setup Instructions
 

--- a/src/screens/InputScreen.tsx
+++ b/src/screens/InputScreen.tsx
@@ -32,6 +32,7 @@ function formatTimeAgo(timestamp: number): string {
 const STORAGE_KEY_GITHUB = 'isscope_github_token';
 const STORAGE_KEY_OPENROUTER = 'isscope_openrouter_key';
 const STORAGE_KEY_MAX_ISSUES = 'isscope_max_issues';
+const STORAGE_KEY_REMEMBER_KEYS = 'isscope_remember_keys';
 
 export function InputScreen() {
   const {
@@ -62,14 +63,20 @@ export function InputScreen() {
   const [localOpenRouterKey, setLocalOpenRouterKey] = useState(openRouterKey);
   const [localMaxIssues, setLocalMaxIssues] = useState(maxIssues);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
+  const [rememberKeys, setRememberKeys] = useState(false);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   // Load API keys from localStorage on mount
   useEffect(() => {
-    const storedGithub = localStorage.getItem(STORAGE_KEY_GITHUB) || '';
-    const storedOpenRouter = localStorage.getItem(STORAGE_KEY_OPENROUTER) || '';
+    const shouldRemember = localStorage.getItem(STORAGE_KEY_REMEMBER_KEYS) === 'true';
+    const storedGithub = shouldRemember ? localStorage.getItem(STORAGE_KEY_GITHUB) || '' : '';
+    const storedOpenRouter = shouldRemember
+      ? localStorage.getItem(STORAGE_KEY_OPENROUTER) || ''
+      : '';
     const storedMaxIssues = localStorage.getItem(STORAGE_KEY_MAX_ISSUES);
+
+    setRememberKeys(shouldRemember);
 
     if (storedGithub || storedOpenRouter) {
       setApiKeys({
@@ -85,7 +92,6 @@ export function InputScreen() {
       }
     }
 
-    // Update local state
     setLocalGithubToken(storedGithub);
     setLocalOpenRouterKey(storedOpenRouter);
     setLocalMaxIssues(storedMaxIssues ? parseInt(storedMaxIssues, 10) : CONFIG.DEFAULT_MAX_ISSUES);
@@ -142,19 +148,25 @@ export function InputScreen() {
   const handleSaveApiKeys = () => {
     setSaveStatus('saving');
 
-    // Save to localStorage
-    localStorage.setItem(STORAGE_KEY_GITHUB, localGithubToken);
-    localStorage.setItem(STORAGE_KEY_OPENROUTER, localOpenRouterKey);
+    if (rememberKeys) {
+      localStorage.setItem(STORAGE_KEY_GITHUB, localGithubToken);
+      localStorage.setItem(STORAGE_KEY_OPENROUTER, localOpenRouterKey);
+      localStorage.setItem(STORAGE_KEY_REMEMBER_KEYS, 'true');
+    } else {
+      localStorage.removeItem(STORAGE_KEY_GITHUB);
+      localStorage.removeItem(STORAGE_KEY_OPENROUTER);
+      localStorage.setItem(STORAGE_KEY_REMEMBER_KEYS, 'false');
+    }
+
     localStorage.setItem(STORAGE_KEY_MAX_ISSUES, localMaxIssues.toString());
 
-    // Update store
     setApiKeys({
       githubToken: localGithubToken,
       openRouterKey: localOpenRouterKey,
     });
+
     setMaxIssues(localMaxIssues);
 
-    // Show success state
     setTimeout(() => {
       setSaveStatus('saved');
       setTimeout(() => setSaveStatus('idle'), 2000);
@@ -660,6 +672,27 @@ export function InputScreen() {
                     Limits the number of issues fetched from GitHub. Lower values are faster.
                   </div>
                 </div>
+
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    fontSize: '13px',
+                    color: 'var(--text-muted)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={rememberKeys}
+                    onChange={(e) => {
+                      setRememberKeys(e.target.checked);
+                      setSaveStatus('idle');
+                    }}
+                  />
+                  Remember API keys
+                </label>
 
                 <Button
                   onClick={handleSaveApiKeys}

--- a/src/screens/InputScreen.tsx
+++ b/src/screens/InputScreen.tsx
@@ -92,9 +92,16 @@ export function InputScreen() {
       }
     }
 
-    setLocalGithubToken(storedGithub);
-    setLocalOpenRouterKey(storedOpenRouter);
-    setLocalMaxIssues(storedMaxIssues ? parseInt(storedMaxIssues, 10) : CONFIG.DEFAULT_MAX_ISSUES);
+    if (storedGithub) setLocalGithubToken(storedGithub);
+    if (storedOpenRouter) setLocalOpenRouterKey(storedOpenRouter);
+
+    if (storedMaxIssues) {
+      const parsed = parseInt(storedMaxIssues, 10);
+
+      if (!isNaN(parsed)) {
+        setLocalMaxIssues(parsed);
+      }
+    }
   }, [setApiKeys, setMaxIssues]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Implemented Option B for API key persistence.

### Changes
* Added a "Remember API keys" toggle in the configuration panel
* API keys are now stored only in memory by default
* localStorage persistence only occurs when explicitly enabled
* Persisted keys are removed when the toggle is disabled
* Updated README privacy wording to accurately reflect behavior

Closes #42

## Type of Change
* [x] Bug fix
* [x] Documentation update

## Checklist
* [x] My code follows the project's coding standards
* [x] I have tested my changes locally
* [x] I have run lint, typecheck, and build successfully
* [x] I have reviewed my own changes
* [x] I have updated documentation where necessary

## Testing

Ran successfully:
* `bun run lint`
* `bun run typecheck`
* `bun run build`

Tested the following flows manually:

* API keys are not persisted by default
* Keys persist only when "Remember API keys" is enabled
* Stored keys are removed when the toggle is disabled
* Existing functionality continues to work as expected

## AI Disclosure
**Did you use AI tools to assist with this PR?**
Yes

**If yes, provide details:**
Used ChatGPT for Rules implementation guidance and PR drafting assistance.

**Declaration:**
I confirm that I reviewed all AI-assisted changes for quality, and adherence to project standards, and I take full responsibility for the submitted changes.

d4f81b746
