### PR TITLE
docs(utils): add JSDoc comments to formatter utilities

### DIFF
--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -1,5 +1,8 @@
 // ── Formatters ────────────────────────────────────
 
+/**
+ * Format an ISO timestamp into a readable date.
+ */
 export function formatTimestamp(iso: string): string {
   const date = new Date(iso);
   return date.toLocaleDateString('en-US', {
@@ -9,6 +12,9 @@ export function formatTimestamp(iso: string): string {
   });
 }
 
+/**
+ * Convert an ISO timestamp into a relative time string.
+ */
 export function formatTimeAgo(iso: string): string {
   const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
   const intervals = [
@@ -23,19 +29,29 @@ export function formatTimeAgo(iso: string): string {
     const count = Math.floor(seconds / interval.seconds);
     if (count >= 1) return `${count}${interval.label} ago`;
   }
+
   return 'just now';
 }
 
+/**
+ * Truncate a string to the given length.
+ */
 export function truncate(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str;
   return str.slice(0, maxLen - 1) + '…';
 }
 
+/**
+ * Get the display label for a complexity score.
+ */
 export function complexityLabel(n: number): string {
   const labels = ['—', 'Trivial', 'Simple', 'Moderate', 'Complex', 'Major Rewrite'];
   return labels[n] || '—';
 }
 
+/**
+ * Get the display label for a newcomer-friendliness score.
+ */
 export function friendlinessLabel(n: number): string {
   const labels = [
     '—',
@@ -45,9 +61,13 @@ export function friendlinessLabel(n: number): string {
     'Beginner Friendly',
     'Great First Issue',
   ];
+
   return labels[n] || '—';
 }
 
+/**
+ * Convert a progress state into a readable label.
+ */
 export function progressLabel(p: string): string {
   const map: Record<string, string> = {
     not_started: 'Not Started',
@@ -55,9 +75,13 @@ export function progressLabel(p: string): string {
     midway: 'In Progress',
     nearly_done: 'Nearly Done',
   };
+
   return map[p] || p;
 }
 
+/**
+ * Convert a status key into a readable label.
+ */
 export function statusLabel(s: string): string {
   const map: Record<string, string> = {
     active: 'Active',
@@ -66,5 +90,6 @@ export function statusLabel(s: string): string {
     external: 'External Dep',
     wontfix: "Won't Fix",
   };
+
   return map[s] || s;
 }

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -1,7 +1,10 @@
 // ── Formatters ────────────────────────────────────
 
 /**
- * Format an ISO timestamp into a readable date.
+ * Formats an ISO 8601 timestamp into a readable date string (e.g., "Jan 1, 2023").
+ *
+ * @param iso - The ISO 8601 timestamp string to format.
+ * @returns A formatted date string in the 'en-US' locale.
  */
 export function formatTimestamp(iso: string): string {
   const date = new Date(iso);
@@ -13,7 +16,10 @@ export function formatTimestamp(iso: string): string {
 }
 
 /**
- * Convert an ISO timestamp into a relative time string.
+ * Converts an ISO 8601 timestamp into a relative time string (e.g., "5d ago").
+ *
+ * @param iso - The ISO 8601 timestamp string.
+ * @returns A human-readable relative time string.
  */
 export function formatTimeAgo(iso: string): string {
   const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
@@ -34,7 +40,11 @@ export function formatTimeAgo(iso: string): string {
 }
 
 /**
- * Truncate a string to the given length.
+ * Truncates a string to a specified maximum length, including the ellipsis.
+ *
+ * @param str - The string to truncate.
+ * @param maxLen - The maximum allowed length of the output string, including the ellipsis character.
+ * @returns The truncated string with an ellipsis, or the original string if it is short enough.
  */
 export function truncate(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str;
@@ -42,7 +52,10 @@ export function truncate(str: string, maxLen: number): string {
 }
 
 /**
- * Get the display label for a complexity score.
+ * Returns a display label for a complexity score (1–5).
+ *
+ * @param n - The complexity score from 1 (Trivial) to 5 (Major Rewrite).
+ * @returns The corresponding label string, or '—' if the score is out of range.
  */
 export function complexityLabel(n: number): string {
   const labels = ['—', 'Trivial', 'Simple', 'Moderate', 'Complex', 'Major Rewrite'];
@@ -50,7 +63,10 @@ export function complexityLabel(n: number): string {
 }
 
 /**
- * Get the display label for a newcomer-friendliness score.
+ * Returns a display label for a newcomer-friendliness score (1–5).
+ *
+ * @param n - The friendliness score from 1 (Expert Only) to 5 (Great First Issue).
+ * @returns The corresponding label string, or '—' if the score is out of range.
  */
 export function friendlinessLabel(n: number): string {
   const labels = [
@@ -66,7 +82,10 @@ export function friendlinessLabel(n: number): string {
 }
 
 /**
- * Convert a progress state into a readable label.
+ * Converts a progress state key into a human-readable label.
+ *
+ * @param p - The progress state key (e.g., 'not_started', 'early').
+ * @returns The corresponding display label, or the original key if not found.
  */
 export function progressLabel(p: string): string {
   const map: Record<string, string> = {
@@ -80,7 +99,10 @@ export function progressLabel(p: string): string {
 }
 
 /**
- * Convert a status key into a readable label.
+ * Converts a status key into a human-readable label.
+ *
+ * @param s - The status key (e.g., 'active', 'stale').
+ * @returns The corresponding display label, or the original key if not found.
  */
 export function statusLabel(s: string): string {
   const map: Record<string, string> = {


### PR DESCRIPTION
## Description
Adds JSDoc comments to formatter utility functions in `src/lib/utils/formatters.ts` to improve readability and developer experience.

Closes #2

## Type of Change

- Documentation

## Checklist
- [x] Added JSDoc comments to formatter utilities
- [x] No logic changes
- [x] Ran lint, typecheck, and build successfully

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run build`

## AI Disclosure
Yes. ChatGPT was used solely for grammatical refinement of JSDoc comments, not for generating content. All modifications were manually reviewed and verified.

## Additional Notes
This PR only adds documentation comments and does not modify existing functionality.
