### PR TITLE
🤖🤖🤖 docs(utils): add JSDoc to formatter helpers

### DIFF
--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -1,5 +1,11 @@
 // ── Formatters ────────────────────────────────────
 
+/**
+ * Formats an ISO timestamp as a short US date string.
+ *
+ * @param iso - ISO timestamp to format.
+ * @returns A localized date such as "Jan 1, 2026".
+ */
 export function formatTimestamp(iso: string): string {
   const date = new Date(iso);
   return date.toLocaleDateString('en-US', {
@@ -9,6 +15,12 @@ export function formatTimestamp(iso: string): string {
   });
 }
 
+/**
+ * Converts an ISO timestamp into a compact relative time label.
+ *
+ * @param iso - ISO timestamp to compare against the current time.
+ * @returns A relative label such as "3h ago", or "just now" for recent times.
+ */
 export function formatTimeAgo(iso: string): string {
   const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
   const intervals = [
@@ -26,16 +38,35 @@ export function formatTimeAgo(iso: string): string {
   return 'just now';
 }
 
+/**
+ * Shortens text to a maximum length and appends an ellipsis when truncated.
+ *
+ * @param str - Text to shorten.
+ * @param maxLen - Maximum number of characters in the returned string.
+ * @returns The original text when short enough, otherwise a truncated version.
+ */
 export function truncate(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str;
   return str.slice(0, maxLen - 1) + '…';
 }
 
+/**
+ * Maps a numeric complexity score to a human-readable label.
+ *
+ * @param n - Complexity score from the issue metadata.
+ * @returns The matching complexity label, or an em dash for unknown scores.
+ */
 export function complexityLabel(n: number): string {
   const labels = ['—', 'Trivial', 'Simple', 'Moderate', 'Complex', 'Major Rewrite'];
   return labels[n] || '—';
 }
 
+/**
+ * Maps a numeric contributor-friendliness score to a readable label.
+ *
+ * @param n - Friendliness score from the issue metadata.
+ * @returns The matching friendliness label, or an em dash for unknown scores.
+ */
 export function friendlinessLabel(n: number): string {
   const labels = [
     '—',
@@ -48,6 +79,12 @@ export function friendlinessLabel(n: number): string {
   return labels[n] || '—';
 }
 
+/**
+ * Converts an issue progress value into display text.
+ *
+ * @param p - Stored progress value.
+ * @returns A readable progress label, or the original value when unmapped.
+ */
 export function progressLabel(p: string): string {
   const map: Record<string, string> = {
     not_started: 'Not Started',
@@ -58,6 +95,12 @@ export function progressLabel(p: string): string {
   return map[p] || p;
 }
 
+/**
+ * Converts an issue status value into display text.
+ *
+ * @param s - Stored status value.
+ * @returns A readable status label, or the original value when unmapped.
+ */
 export function statusLabel(s: string): string {
   const map: Record<string, string> = {
     active: 'Active',


### PR DESCRIPTION
## Summary

- Added JSDoc blocks to the formatter helpers in `src/lib/utils/formatters.ts`.
- Documented each function's parameters and return value.
- Kept the change scoped to the utility file requested in the issue.

## Why

This improves developer experience for future contributors by making the formatter utility behavior clearer in editor tooltips and generated documentation.

## Validation

- `npm run typecheck`
- `npm run lint -- src/lib/utils/formatters.ts`
- `npm exec prettier -- --check src/lib/utils/formatters.ts`

## AI Usage Disclosure

This PR was prepared with AI assistance using OpenAI Codex, with human approval for public GitHub activity.

Fixes #2