### PR TITLE
feat(ui): add light theme and wire useTheme toggle

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -50,21 +50,7 @@ export function Header({ rightContent }: HeaderProps) {
 
       {/* Right side */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-        <button
-          onClick={toggleTheme}
-          aria-label="Toggle theme"
-          style={{
-            background: 'none',
-            border: '1px solid var(--border-subtle)',
-            color: 'var(--text-muted)',
-            cursor: 'pointer',
-            borderRadius: '4px',
-            padding: '4px 6px',
-            display: 'flex',
-            alignItems: 'center',
-            transition: 'all 0.15s ease',
-          }}
-        >
+        <button onClick={toggleTheme} aria-label="Toggle theme" className="theme-toggle-btn">
           {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
         </button>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { Monitor } from 'lucide-react';
+import { Monitor, Sun, Moon } from 'lucide-react';
+import { useTheme } from '../../hooks/useTheme';
 
 interface HeaderProps {
   rightContent?: React.ReactNode;
 }
 
 export function Header({ rightContent }: HeaderProps) {
+  const { theme, toggleTheme } = useTheme();
+
   return (
     <header
       style={{
@@ -46,7 +49,27 @@ export function Header({ rightContent }: HeaderProps) {
       </div>
 
       {/* Right side */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>{rightContent}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+        <button
+          onClick={toggleTheme}
+          aria-label="Toggle theme"
+          style={{
+            background: 'none',
+            border: '1px solid var(--border-subtle)',
+            color: 'var(--text-muted)',
+            cursor: 'pointer',
+            borderRadius: '4px',
+            padding: '4px 6px',
+            display: 'flex',
+            alignItems: 'center',
+            transition: 'all 0.15s ease',
+          }}
+        >
+          {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+        </button>
+
+        {rightContent}
+      </div>
     </header>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,26 @@
   --text-xl: 20px;
   --text-2xl: 24px;
 }
+[data-theme='light'] {
+  /* Backgrounds */
+  --bg: #f8f8f8;
+  --bg-secondary: #efefef;
+  --bg-tertiary: #e6e6e6;
+
+  /* Text */
+  --text: #1a1a1a;
+  --text-muted: #555555;
+  --text-dim: #888888;
+
+  /* Accents */
+  --primary: #404040;
+  --border: #d4d4d4;
+  --border-subtle: #e8e8e8;
+
+  /* Cursor & Selection */
+  --cursor: #404040;
+  --selection: rgba(0, 0, 0, 0.08);
+}
 
 /* ── Reset ─────────────────────────────────── */
 *,

--- a/src/index.css
+++ b/src/index.css
@@ -260,3 +260,20 @@ body {
 .transition-default {
   transition: all 0.15s ease;
 }
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 4px 6px;
+  display: flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  transition: all 0.15s ease;
+}
+
+.theme-toggle-btn:hover {
+  border-color: var(--border);
+  color: var(--text);
+}

--- a/src/screens/InputScreen.tsx
+++ b/src/screens/InputScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTheme } from '../hooks/useTheme';
 import { Button } from '../components/ui/Button';
 import { ScreenLayout } from '../components/layout/ScreenLayout';
 import { useAppStore } from '../store/appStore';
@@ -13,6 +14,8 @@ import {
   Save,
   Check,
   Loader2,
+  Sun,
+  Moon,
 } from 'lucide-react';
 import { CONFIG } from '../lib/constants';
 import { historyService } from '../lib/history/historyService';
@@ -211,9 +214,32 @@ export function InputScreen() {
   };
 
   const recentHistory = history.slice(0, 3);
-
+  const { theme, toggleTheme } = useTheme();
   return (
     <ScreenLayout centered>
+      {/* Theme toggle — fixed top-right */}
+      <button
+        onClick={toggleTheme}
+        aria-label="Toggle theme"
+        style={{
+          position: 'fixed',
+          top: '20px',
+          right: '24px',
+          zIndex: 10,
+          background: 'none',
+          border: '1px solid var(--border-subtle)',
+          color: 'var(--text-muted)',
+          cursor: 'pointer',
+          borderRadius: '4px',
+          padding: '8px',
+          display: 'flex',
+          alignItems: 'center',
+          fontFamily: 'var(--font-mono)',
+          transition: 'all 0.15s ease',
+        }}
+      >
+        {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+      </button>
       {/* Grid Background */}
       <div
         style={{

--- a/src/screens/ReportScreen.tsx
+++ b/src/screens/ReportScreen.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '../hooks/useTheme';
 import React, { useMemo, useCallback } from 'react';
 import { SplitPane } from '../components/layout/SplitPane';
 import { IssueList } from '../components/issue/IssueList';
@@ -7,7 +8,7 @@ import { useAppStore } from '../store/appStore';
 import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
 import type { RankedIssue } from '../lib/types';
 import { Button } from '../components/ui/Button';
-import { Download, RotateCcw } from 'lucide-react';
+import { Download, RotateCcw, Sun, Moon } from 'lucide-react';
 import { parseRepoInput } from '../lib/utils/validators';
 import { exportToMarkdown, downloadMarkdown } from '../lib/utils/exporters';
 
@@ -67,6 +68,7 @@ export function ReportScreen() {
   }, [filteredIssues, selectedIssueId]);
 
   const { repoInput, reset } = useAppStore();
+  const { theme, toggleTheme } = useTheme();
 
   // Header actions
   const handleExport = useCallback(() => {
@@ -93,6 +95,9 @@ export function ReportScreen() {
           Report: {repoInput}
         </div>
         <div style={{ display: 'flex', gap: '6px' }}>
+          <Button variant="ghost" size="sm" onClick={toggleTheme} title="Toggle theme">
+            {theme === 'dark' ? <Sun size={13} /> : <Moon size={13} />}
+          </Button>
           <Button variant="ghost" size="sm" onClick={handleExport} title="Export Markdown report">
             <Download size={13} /> Export
           </Button>


### PR DESCRIPTION
Closes #14

## Description

Adds a fully functional light theme using the existing `useTheme` hook and CSS variable system.

Implemented:

* `[data-theme='light']` CSS variable overrides in `src/index.css`
* Theme toggle button using `lucide-react`
* Theme persistence via existing localStorage logic
* Support for switching between dark and light themes on the landing page

## Type of Change

* [x] Enhancement (non-breaking feature addition)

## Checklist

* [x] Code follows project style guidelines
* [x] `bun run typecheck` passes
* [x] `bun run lint` passes (existing repository warnings only)
* [x] `bun run build` passes
* [x] UI tested in both dark and light themes

## Testing

Tested:

* Theme toggle functionality
* Theme persistence after page refresh
* Visual readability in both themes
* Responsive positioning of the toggle button

Commands run:

```bash
bun run typecheck
bun run lint
bun run build
```

## Screenshots [TOP MOST RIGHT CORNER(BUTTON)]
<img width="2860" height="1383" alt="image" src="https://github.com/user-attachments/assets/64ddd3cf-ca80-4ef5-a356-1af1829d6c72" />
<img width="2867" height="1483" alt="image" src="https://github.com/user-attachments/assets/e22fbf58-ce9e-4144-92bc-7a0bfeafa116" />

### Dark Theme

(Add dark theme screenshot here)

### Light Theme

(Add light theme screenshot here)

## AI Disclosure

**Did you use AI tools to assist with this PR?**
Yes

**If yes, provide details:**
Used Claude,ChatGPT for implementation guidance, debugging assistance, and review.

**Declaration:**
I reviewed and verified all generated suggestions and take full responsibility for the submitted changes.

## Additional Notes

This implementation reuses the already existing `useTheme` hook instead of introducing a new state management solution, keeping the changes minimal and aligned with the current architecture.
