### PR TITLE
fix: add maxIssues to useCallback dependency array (#36)

### DIFF
--- a/src/hooks/useGitHubIssues.ts
+++ b/src/hooks/useGitHubIssues.ts
@@ -133,6 +133,7 @@ export function useGitHubIssues() {
     },
     [
       repoInput,
+      maxIssues,
       setIssues,
       setAnalyses,
       analyses,


### PR DESCRIPTION
## Description
Adds maxIssues to the dependency array of the etchIssues useCallback to fix a stale closure. When the user changes the maxIssues setting in the config panel, the callback now picks up the new value instead of using the initial one.

Closes #36