### PR TITLE
refactor: remove duplicate utility functions and import from shared modules (#39)

### DIFF
--- a/src/hooks/useIssueAnalysis.ts
+++ b/src/hooks/useIssueAnalysis.ts
@@ -109,5 +109,3 @@ export function useIssueAnalysis() {
 
   return { analyzeIssues, cancel };
 }
-
-

--- a/src/hooks/useIssueAnalysis.ts
+++ b/src/hooks/useIssueAnalysis.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 import { useAppStore } from '../store/appStore';
 import { analyzeAllIssues } from '../lib/api/openrouter';
 import { historyService } from '../lib/history/historyService';
+import { parseRepoInput } from '../lib/utils/validators';
 import type { Issue } from '../lib/types';
 
 export function useIssueAnalysis() {
@@ -109,19 +110,4 @@ export function useIssueAnalysis() {
   return { analyzeIssues, cancel };
 }
 
-function parseRepoInput(input: string): { owner: string; repo: string } {
-  // Handle full URL or owner/repo format
-  if (input.includes('github.com')) {
-    const match = input.match(/github\.com\/([^/]+)\/([^/]+)/);
-    if (match) {
-      return { owner: match[1], repo: match[2].replace(/\.git$/, '') };
-    }
-  }
 
-  const parts = input.split('/');
-  if (parts.length >= 2) {
-    return { owner: parts[0], repo: parts[1].replace(/\.git$/, '') };
-  }
-
-  throw new Error('Invalid repository format');
-}

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -21,8 +21,9 @@ export function formatTimestamp(iso: string): string {
  * @param iso - The ISO 8601 timestamp string.
  * @returns A human-readable relative time string.
  */
-export function formatTimeAgo(iso: string): string {
-  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
+export function formatTimeAgo(ts: string | number): string {
+  const date = typeof ts === 'number' ? new Date(ts) : new Date(ts);
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
   const intervals = [
     { label: 'y', seconds: 31536000 },
     { label: 'mo', seconds: 2592000 },

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -22,7 +22,7 @@ export function formatTimestamp(iso: string): string {
  * @returns A human-readable relative time string.
  */
 export function formatTimeAgo(ts: string | number): string {
-  const date = typeof ts === 'number' ? new Date(ts) : new Date(ts);
+  const date = new Date(ts);
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
   const intervals = [
     { label: 'y', seconds: 31536000 },

--- a/src/screens/InputScreen.tsx
+++ b/src/screens/InputScreen.tsx
@@ -16,17 +16,7 @@ import {
 } from 'lucide-react';
 import { CONFIG } from '../lib/constants';
 import { historyService } from '../lib/history/historyService';
-
-function formatTimeAgo(timestamp: number): string {
-  const seconds = Math.floor((Date.now() - timestamp) / 1000);
-  if (seconds < 60) return 'just now';
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
+import { formatTimeAgo } from '../lib/utils/formatters';
 
 // Storage keys for localStorage
 const STORAGE_KEY_GITHUB = 'isscope_github_token';


### PR DESCRIPTION
## Description
Removed two duplicated utility functions and replaced them with imports from shared modules:

1. **useIssueAnalysis.ts**: Removed local parseRepoInput (line 112), now imported from alidators.ts
2. **InputScreen.tsx**: Removed local ormatTimeAgo (line 21), now imported from ormatters.ts  
3. **formatters.ts**: Updated ormatTimeAgo signature to accept 
umber | string to support both timestamp and ISO string inputs

Closes #39