### PR TITLE
feat: add empty-state illustration when no issues found

### DIFF
--- a/src/components/issue/IssueList.tsx
+++ b/src/components/issue/IssueList.tsx
@@ -172,6 +172,11 @@ export function IssueList({
               fontFamily: 'var(--font-mono)',
             }}
           >
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ margin: '0 auto 12px', opacity: 0.4, display: 'block' }}>
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+              <line x1="8" y1="11" x2="14" y2="11" />
+            </svg>
             {searchQuery ? 'No issues match your search.' : 'No issues found.'}
           </div>
         ) : (


### PR DESCRIPTION
Closes #17

### Changes
- Added a magnifying glass SVG illustration when no issues match the search or no issues are found

### Files changed
- src/components/issue/IssueList.tsx