### PR TITLE
feat: add local LLM provider (Ollama / LMStudio) support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 VITE_GITHUB_TOKEN=
 VITE_OPENROUTER_API_KEY=
 VITE_MODEL_NAME=
+# Optional overrides for the Local (Ollama / LMStudio) provider.
+# When using the Local provider, set these in the UI — these build-time
+# defaults are only used if the user has not configured anything in-app.
+VITE_LOCAL_ENDPOINT=
+VITE_LOCAL_MODEL=

--- a/src/hooks/useIssueAnalysis.ts
+++ b/src/hooks/useIssueAnalysis.ts
@@ -1,12 +1,12 @@
 import { useCallback, useRef } from 'react';
 import { useAppStore } from '../store/appStore';
-import { analyzeAllIssues } from '../lib/api/openrouter';
+import { analyzeAllIssues } from '../lib/api/provider';
 import { historyService } from '../lib/history/historyService';
 import { parseRepoInput } from '../lib/utils/validators';
 import type { Issue } from '../lib/types';
 
 export function useIssueAnalysis() {
-  const { setAnalysis, setFetchProgress, setScreen, addLog, repoInput } = useAppStore();
+  const { setAnalysis, setFetchProgress, setScreen, addLog, repoInput, aiProvider } = useAppStore();
 
   const cancelRef = useRef(false);
 
@@ -69,7 +69,15 @@ export function useIssueAnalysis() {
 
       addLog(`Analyzing ${issuesToAnalyze.length} issues with AI...`, 'info');
 
-      addLog(`Model: ${import.meta.env.VITE_MODEL_NAME || 'openai/gpt-oss-20b:free'}`, 'info');
+      if (aiProvider === 'local') {
+        const { localEndpoint, localModel } = useAppStore.getState();
+        addLog(`Provider: local (${localEndpoint} — ${localModel})`, 'info');
+      } else {
+        addLog(
+          `Provider: OpenRouter (${import.meta.env.VITE_MODEL_NAME || 'openai/gpt-oss-20b:free'})`,
+          'info',
+        );
+      }
 
       setFetchProgress({
         phase: 'analyzing',
@@ -120,7 +128,7 @@ export function useIssueAnalysis() {
       // Transition to report
       setScreen('report');
     },
-    [setAnalysis, setFetchProgress, setScreen, addLog, repoInput],
+    [setAnalysis, setFetchProgress, setScreen, addLog, repoInput, aiProvider],
   );
 
   const cancel = useCallback(() => {

--- a/src/lib/api/local.test.ts
+++ b/src/lib/api/local.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { callLocal, resolveLocalConfig, isLocalConfigured } from './local';
+
+describe('Local LLM client', () => {
+  let mockFetch: any;
+
+  function createMockResponse(status: number, data: any) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      json: async () => data,
+      text: async () => (typeof data === 'string' ? data : JSON.stringify(data)),
+    };
+  }
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe('callLocal', () => {
+    it('POSTs to <endpoint>/chat/completions with the model and messages', async () => {
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, {
+          choices: [{ message: { content: 'hi' } }],
+        }),
+      );
+
+      const out = await callLocal('system', 'user', {
+        endpoint: 'http://localhost:11434/v1',
+        model: 'llama3.2',
+      });
+
+      expect(out).toBe('hi');
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:11434/v1/chat/completions');
+      expect(options.method).toBe('POST');
+      expect(options.headers['Content-Type']).toBe('application/json');
+      const body = JSON.parse(options.body);
+      expect(body.model).toBe('llama3.2');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'system' },
+        { role: 'user', content: 'user' },
+      ]);
+      // Local providers should not get the strict json_object response_format
+      // (some local backends reject it).
+      expect(body.response_format).toBeUndefined();
+    });
+
+    it('strips trailing slashes from the endpoint', async () => {
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, { choices: [{ message: { content: 'x' } }] }),
+      );
+
+      await callLocal('s', 'u', { endpoint: 'http://localhost:1234/v1///', model: 'm' });
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:1234/v1/chat/completions');
+    });
+
+    it('sends an Authorization header only when an API key is configured', async () => {
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, { choices: [{ message: { content: 'x' } }] }),
+      );
+
+      await callLocal('s', 'u', {
+        endpoint: 'http://localhost:1234/v1',
+        model: 'm',
+      });
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBeUndefined();
+
+      mockFetch.mockClear();
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, { choices: [{ message: { content: 'x' } }] }),
+      );
+
+      await callLocal('s', 'u', {
+        endpoint: 'http://localhost:1234/v1',
+        model: 'm',
+        apiKey: 'lm-studio',
+      });
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer lm-studio');
+    });
+
+    it('throws RATE_LIMITED on 429', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(429, {}));
+
+      await expect(callLocal('s', 'u', { endpoint: 'http://x', model: 'm' })).rejects.toThrow(
+        'RATE_LIMITED',
+      );
+    });
+
+    it('throws a descriptive error on non-ok responses', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(503, 'service down'));
+
+      await expect(callLocal('s', 'u', { endpoint: 'http://x', model: 'm' })).rejects.toThrow(
+        /Local LLM error 503/,
+      );
+    });
+  });
+
+  describe('resolveLocalConfig', () => {
+    it('falls back to defaults when no override is given', () => {
+      const cfg = resolveLocalConfig();
+      expect(cfg.endpoint).toBeTruthy();
+      expect(cfg.model).toBeTruthy();
+      expect(cfg.apiKey).toBeUndefined();
+    });
+
+    it('uses override values when provided', () => {
+      const cfg = resolveLocalConfig({
+        endpoint: 'http://example.local:9000/v1',
+        model: 'mistral',
+        apiKey: 'abc',
+      });
+      expect(cfg.endpoint).toBe('http://example.local:9000/v1');
+      expect(cfg.model).toBe('mistral');
+      expect(cfg.apiKey).toBe('abc');
+    });
+
+    it('ignores blank/whitespace override values and keeps the default', () => {
+      const cfg = resolveLocalConfig({ endpoint: '   ', model: '' });
+      expect(cfg.endpoint).toBeTruthy();
+      expect(cfg.model).toBeTruthy();
+    });
+  });
+
+  describe('isLocalConfigured', () => {
+    it('returns true when both endpoint and model are present', () => {
+      expect(isLocalConfigured({ endpoint: 'http://x', model: 'm' })).toBe(true);
+    });
+
+    it('returns false when endpoint is empty', () => {
+      expect(isLocalConfigured({ endpoint: '', model: 'm' })).toBe(false);
+    });
+
+    it('returns false when model is empty', () => {
+      expect(isLocalConfigured({ endpoint: 'http://x', model: '' })).toBe(false);
+    });
+  });
+});

--- a/src/lib/api/local.ts
+++ b/src/lib/api/local.ts
@@ -1,0 +1,66 @@
+import { CONFIG } from '../constants';
+import type { AnalysisResult, Issue, LocalProviderConfig } from '../types';
+
+export interface LocalProviderOptions {
+  endpoint: string;
+  model: string;
+  apiKey?: string;
+}
+
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint.replace(/\/+$/, '');
+}
+
+export async function callLocal(
+  prompt: string,
+  userMessage: string,
+  options: LocalProviderOptions,
+): Promise<string> {
+  const endpoint = normalizeEndpoint(options.endpoint);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (options.apiKey) {
+    headers.Authorization = `Bearer ${options.apiKey}`;
+  }
+
+  const response = await fetch(`${endpoint}/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: options.model,
+      messages: [
+        { role: 'system', content: prompt },
+        { role: 'user', content: userMessage },
+      ],
+      temperature: 0.3,
+      max_tokens: 1024,
+    }),
+  });
+
+  if (response.status === 429) {
+    throw new Error('RATE_LIMITED');
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Local LLM error ${response.status}: ${errorText}`);
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content || '';
+}
+
+export function resolveLocalConfig(override?: Partial<LocalProviderConfig>): LocalProviderConfig {
+  return {
+    endpoint: override?.endpoint?.trim() || CONFIG.DEFAULT_LOCAL_ENDPOINT,
+    model: override?.model?.trim() || CONFIG.DEFAULT_LOCAL_MODEL,
+    apiKey: override?.apiKey?.trim() || undefined,
+  };
+}
+
+export function isLocalConfigured(config: LocalProviderConfig): boolean {
+  return Boolean(config.endpoint) && Boolean(config.model);
+}
+
+export type { Issue, AnalysisResult };

--- a/src/lib/api/openrouter.test.ts
+++ b/src/lib/api/openrouter.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { analyzeIssue, analyzeAllIssues } from './openrouter';
+import { callOpenRouter } from './openrouter';
+import { analyzeIssue, analyzeAllIssues } from './provider';
 import { useAppStore } from '../../store/appStore';
 import type { Issue } from '../types';
 
 describe('OpenRouter API Client', () => {
   let mockFetch: any;
 
-  // Helper to create mocked Response
   function createMockResponse(status: number, data: any) {
     return {
       ok: status >= 200 && status < 300,
@@ -48,21 +48,24 @@ describe('OpenRouter API Client', () => {
     mockFetch = vi.fn();
     vi.stubGlobal('fetch', mockFetch);
 
-    // Mock window global to avoid runtime ReferenceErrors
     vi.stubGlobal('window', {
       location: {
         origin: 'https://isscope-mock.com',
       },
     });
 
-    // Avoid real retry delays in test environment
     vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: any) => {
       fn();
       return 0 as any;
     });
 
-    // Reset openrouter keys
-    useAppStore.setState({ openRouterKey: '' });
+    useAppStore.setState({
+      openRouterKey: '',
+      aiProvider: 'openrouter',
+      localEndpoint: 'http://localhost:11434/v1',
+      localModel: 'llama3.2',
+      localApiKey: '',
+    });
   });
 
   afterEach(() => {
@@ -70,30 +73,82 @@ describe('OpenRouter API Client', () => {
     vi.unstubAllGlobals();
   });
 
-  describe('callOpenRouter & Configurations', () => {
-    it('throws error if OpenRouter Key is missing', async () => {
-      useAppStore.setState({ openRouterKey: '' });
+  describe('callOpenRouter', () => {
+    it('throws an explicit error when API Key is missing', async () => {
+      await expect(callOpenRouter('system', 'user', '')).rejects.toThrow(
+        /OpenRouter API Key is missing/,
+      );
+    });
+
+    it('makes expected HTTP request with Bearer auth and OpenRouter headers', async () => {
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, {
+          choices: [{ message: { content: 'hello' } }],
+        }),
+      );
+
+      const out = await callOpenRouter(
+        'system prompt',
+        'user message',
+        'openrouter-secret-key',
+        'openai/gpt-oss-20b:free',
+      );
+
+      expect(out).toBe('hello');
+      expect(mockFetch).toHaveBeenCalled();
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('https://openrouter.ai/api/v1/chat/completions');
+      expect(options.method).toBe('POST');
+      expect(options.headers['Authorization']).toBe('Bearer openrouter-secret-key');
+      expect(options.headers['HTTP-Referer']).toBe('https://isscope-mock.com');
+      expect(options.headers['X-Title']).toBe('Isscope');
+      expect(options.headers['Content-Type']).toBe('application/json');
+      const body = JSON.parse(options.body);
+      expect(body.model).toBe('openai/gpt-oss-20b:free');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'user message' },
+      ]);
+      expect(body.response_format).toEqual({ type: 'json_object' });
+    });
+
+    it('throws RATE_LIMITED on 429 status', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(429, {}));
+
+      await expect(callOpenRouter('s', 'u', 'k')).rejects.toThrow('RATE_LIMITED');
+    });
+
+    it('throws descriptive error on non-ok responses', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(500, 'boom'));
+
+      await expect(callOpenRouter('s', 'u', 'k')).rejects.toThrow(/OpenRouter error 500/);
+    });
+
+    it('returns an empty string when the response has no message content', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(200, { choices: [] }));
+
+      const out = await callOpenRouter('s', 'u', 'k');
+      expect(out).toBe('');
+    });
+  });
+
+  describe('provider dispatch', () => {
+    it('falls back to DEFAULT_ANALYSIS with an error note when OpenRouter key is missing', async () => {
+      useAppStore.setState({ openRouterKey: '', aiProvider: 'openrouter' });
 
       const logSpy = vi.fn();
       const result = await analyzeIssue(mockIssue, logSpy);
 
-      // Falls back to DEFAULT_ANALYSIS with error noted
       expect(result.analysis_notes).toContain('OpenRouter API Key is missing');
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to analyze'));
     });
 
-    it('makes expected HTTP request when API Key is configured', async () => {
+    it('calls OpenRouter and parses the result when key is configured', async () => {
       useAppStore.setState({ openRouterKey: 'openrouter-secret-key' });
 
       mockFetch.mockResolvedValue(
         createMockResponse(200, {
-          choices: [
-            {
-              message: {
-                content: JSON.stringify(validAnalysisJSON),
-              },
-            },
-          ],
+          choices: [{ message: { content: JSON.stringify(validAnalysisJSON) } }],
         }),
       );
 
@@ -104,13 +159,49 @@ describe('OpenRouter API Client', () => {
       expect(fetchArgs[0]).toContain('/chat/completions');
 
       const options = fetchArgs[1];
-      expect(options.method).toBe('POST');
       expect(options.headers['Authorization']).toBe('Bearer openrouter-secret-key');
-      expect(options.headers['HTTP-Referer']).toBe('https://isscope-mock.com');
-
-      // Verify the parsed result matches valid JSON
       expect(result.doability_score).toBe(95);
       expect(result.complexity).toBe(1);
+    });
+
+    it('dispatches to the local provider when aiProvider is "local"', async () => {
+      useAppStore.setState({
+        aiProvider: 'local',
+        localEndpoint: 'http://localhost:11434/v1',
+        localModel: 'qwen2.5-coder:7b',
+        localApiKey: '',
+      });
+
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, {
+          choices: [{ message: { content: JSON.stringify(validAnalysisJSON) } }],
+        }),
+      );
+
+      const result = await analyzeIssue(mockIssue);
+
+      expect(mockFetch).toHaveBeenCalled();
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:11434/v1/chat/completions');
+      expect(options.headers['Authorization']).toBeUndefined();
+      const body = JSON.parse(options.body);
+      expect(body.model).toBe('qwen2.5-coder:7b');
+      expect(body.response_format).toBeUndefined();
+      expect(result.doability_score).toBe(95);
+    });
+
+    it('honors an explicit provider override even when store default differs', async () => {
+      useAppStore.setState({ aiProvider: 'openrouter', openRouterKey: 'k' });
+
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, {
+          choices: [{ message: { content: JSON.stringify(validAnalysisJSON) } }],
+        }),
+      );
+
+      const result = await analyzeIssue(mockIssue, undefined, 'openrouter');
+
+      expect(result.doability_score).toBe(95);
     });
   });
 
@@ -118,7 +209,6 @@ describe('OpenRouter API Client', () => {
     it('retries on RATE_LIMITED (429) up to 3 times before failing', async () => {
       useAppStore.setState({ openRouterKey: 'valid-key' });
 
-      // Return 429 three times
       mockFetch.mockResolvedValue(createMockResponse(429, {}));
 
       const logSpy = vi.fn();
@@ -132,8 +222,6 @@ describe('OpenRouter API Client', () => {
     it('retries on 429 and succeeds if rate limit clears', async () => {
       useAppStore.setState({ openRouterKey: 'valid-key' });
 
-      // First call: 429
-      // Second call: 200 OK
       mockFetch.mockResolvedValueOnce(createMockResponse(429, {})).mockResolvedValueOnce(
         createMockResponse(200, {
           choices: [{ message: { content: JSON.stringify(validAnalysisJSON) } }],
@@ -169,7 +257,6 @@ describe('OpenRouter API Client', () => {
     it('salvages partial JSON responses with partial field data', async () => {
       useAppStore.setState({ openRouterKey: 'valid-key' });
 
-      // Incomplete schema: missing progress_estimate, skills_required, newcomer_friendliness
       const partialJSON = {
         summary: 'Partial analysis results.',
         doability_score: 75,
@@ -187,7 +274,6 @@ describe('OpenRouter API Client', () => {
       expect(result.summary).toBe('Partial analysis results.');
       expect(result.doability_score).toBe(75);
       expect(result.complexity).toBe(3);
-      // Fallback values applied
       expect(result.status).toBe('active');
       expect(result.analysis_notes).toBe('Partially parsed from AI response.');
     });
@@ -235,6 +321,38 @@ describe('OpenRouter API Client', () => {
       expect(analyses.get(1)?.doability_score).toBe(95);
       expect(analyses.get(2)?.doability_score).toBe(95);
       expect(progressSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses lower concurrency for the local provider', async () => {
+      useAppStore.setState({ aiProvider: 'local' });
+
+      const issueA = { ...mockIssue, number: 1 };
+      const issueB = { ...mockIssue, number: 2 };
+      const issueC = { ...mockIssue, number: 3 };
+
+      mockFetch.mockResolvedValue(
+        createMockResponse(200, {
+          choices: [{ message: { content: JSON.stringify(validAnalysisJSON) } }],
+        }),
+      );
+
+      let concurrentPeak = 0;
+      let inFlight = 0;
+      const originalThen = mockFetch.mockImplementation(async () => {
+        inFlight++;
+        concurrentPeak = Math.max(concurrentPeak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return createMockResponse(200, {
+          choices: [{ message: { content: JSON.stringify(validAnalysisJSON) } }],
+        });
+      });
+
+      await analyzeAllIssues([issueA, issueB, issueC]);
+
+      expect(concurrentPeak).toBeLessThanOrEqual(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      originalThen.mockRestore();
     });
 
     it('respects cancellation tokens', async () => {

--- a/src/lib/api/openrouter.ts
+++ b/src/lib/api/openrouter.ts
@@ -1,67 +1,23 @@
-import { CONFIG, ANALYSIS_PROMPT } from '../constants';
-import { AnalysisResultSchema, type AnalysisResult, type Issue } from '../types';
+import { CONFIG } from '../constants';
 
-function formatIssueForAnalysis(issue: Issue): string {
-  const parts = [
-    `# Issue #${issue.number}: ${issue.title}`,
-    ``,
-    `**Author**: ${issue.user.login}`,
-    `**Created**: ${issue.created_at}`,
-    `**Updated**: ${issue.updated_at}`,
-    `**Labels**: ${issue.labels.map((l) => l.name).join(', ') || 'none'}`,
-    `**Assignees**: ${issue.assignees.map((a) => a.login).join(', ') || 'none'}`,
-    `**Comment count**: ${issue.comments_count}`,
-    ``,
-    `## Body`,
-    issue.body || '(no description)',
-  ];
-
-  if (issue.comments && issue.comments.length > 0) {
-    parts.push('', '## Comments');
-    for (const comment of issue.comments.slice(0, 15)) {
-      parts.push(
-        ``,
-        `### @${comment.user.login} (${comment.created_at})`,
-        comment.body.slice(0, 500),
-      );
-    }
-  }
-
-  if (issue.timeline && issue.timeline.length > 0) {
-    parts.push('', '## Timeline Events');
-    const relevant = issue.timeline
-      .filter((e) => ['cross-referenced', 'referenced', 'labeled', 'assigned'].includes(e.event))
-      .slice(0, 10);
-    for (const event of relevant) {
-      parts.push(`- ${event.event} by ${event.actor?.login || 'unknown'} at ${event.created_at}`);
-    }
-  }
-
-  return parts.join('\n');
+export interface OpenRouterOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
 }
 
-const DEFAULT_ANALYSIS: AnalysisResult = {
-  summary: 'Analysis could not be completed.',
-  status: 'active',
-  progress_estimate: 'not_started',
-  is_actionable_code_change: true,
-  not_mergeable_reason: null,
-  complexity: 3,
-  skills_required: [],
-  newcomer_friendliness: 3,
-  doability_score: 50,
-  analysis_notes: 'Fallback default — AI analysis failed or returned invalid data.',
-};
-
-import { useAppStore } from '../../store/appStore';
-
-async function callOpenRouter(prompt: string, userMessage: string): Promise<string> {
-  const apiKey = useAppStore.getState().openRouterKey;
+export async function callOpenRouter(
+  prompt: string,
+  userMessage: string,
+  apiKey: string,
+  model: string = CONFIG.DEFAULT_MODEL,
+  baseUrl: string = CONFIG.OPENROUTER_API_BASE,
+): Promise<string> {
   if (!apiKey) {
     throw new Error('OpenRouter API Key is missing. Please configure it.');
   }
 
-  const response = await fetch(`${CONFIG.OPENROUTER_API_BASE}/chat/completions`, {
+  const response = await fetch(`${baseUrl}/chat/completions`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -70,7 +26,7 @@ async function callOpenRouter(prompt: string, userMessage: string): Promise<stri
       'X-Title': 'Isscope',
     },
     body: JSON.stringify({
-      model: CONFIG.DEFAULT_MODEL,
+      model,
       messages: [
         { role: 'system', content: prompt },
         { role: 'user', content: userMessage },
@@ -94,123 +50,4 @@ async function callOpenRouter(prompt: string, userMessage: string): Promise<stri
   return data.choices?.[0]?.message?.content || '';
 }
 
-function parseAnalysisResponse(raw: string): AnalysisResult {
-  try {
-    // Try to extract JSON from the raw response
-    let jsonStr = raw.trim();
-
-    // Handle markdown code fences
-    const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (jsonMatch) {
-      jsonStr = jsonMatch[1].trim();
-    }
-
-    const parsed = JSON.parse(jsonStr);
-    const validated = AnalysisResultSchema.parse(parsed);
-    return validated;
-  } catch {
-    // Try to salvage partial data
-    try {
-      const parsed = JSON.parse(raw.trim());
-      return {
-        ...DEFAULT_ANALYSIS,
-        summary: parsed.summary || DEFAULT_ANALYSIS.summary,
-        doability_score:
-          typeof parsed.doability_score === 'number'
-            ? parsed.doability_score
-            : DEFAULT_ANALYSIS.doability_score,
-        complexity:
-          typeof parsed.complexity === 'number' ? parsed.complexity : DEFAULT_ANALYSIS.complexity,
-        skills_required: Array.isArray(parsed.skills_required) ? parsed.skills_required : [],
-        status: parsed.status || DEFAULT_ANALYSIS.status,
-        analysis_notes: parsed.analysis_notes || 'Partially parsed from AI response.',
-      };
-    } catch {
-      return {
-        ...DEFAULT_ANALYSIS,
-        analysis_notes: 'Failed to parse AI response: ' + raw.slice(0, 200),
-      };
-    }
-  }
-}
-
-export async function analyzeIssue(
-  issue: Issue,
-  onLog?: (message: string) => void,
-): Promise<AnalysisResult> {
-  const formatted = formatIssueForAnalysis(issue);
-  onLog?.(`Analyzing #${issue.number}: ${issue.title.slice(0, 60)}...`);
-
-  let retries = 3;
-  let backoff = 2000;
-
-  while (retries > 0) {
-    try {
-      const raw = await callOpenRouter(ANALYSIS_PROMPT, formatted);
-      const result = parseAnalysisResponse(raw);
-      onLog?.(
-        `✓ #${issue.number} analyzed — score: ${result.doability_score}/100, status: ${result.status}`,
-      );
-      return result;
-    } catch (err: unknown) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      if (error.message === 'RATE_LIMITED' && retries > 1) {
-        onLog?.(`⏳ Rate limited. Waiting ${backoff / 1000}s before retry...`);
-        await new Promise((r) => setTimeout(r, backoff));
-        backoff *= 2;
-        retries--;
-        continue;
-      }
-      onLog?.(`✗ Failed to analyze #${issue.number}: ${error.message}`);
-      return { ...DEFAULT_ANALYSIS, analysis_notes: `Error: ${error.message}` };
-    }
-  }
-
-  return DEFAULT_ANALYSIS;
-}
-
-export async function analyzeAllIssues(
-  issues: Issue[],
-  onProgress?: (current: number, total: number) => void,
-  onLog?: (message: string) => void,
-  isCancelled?: () => boolean,
-): Promise<Map<number, AnalysisResult>> {
-  const analyses = new Map<number, AnalysisResult>();
-  const CONCURRENCY = 15;
-  let completed = 0;
-
-  // Chunk array into batches or use a pool. A pool is better for speed.
-  // Simple pool implementation:
-  const queue = [...issues];
-
-  const next = async (): Promise<void> => {
-    if (isCancelled?.() || queue.length === 0) return;
-
-    const issue = queue.shift();
-    if (!issue) return;
-
-    try {
-      const result = await analyzeIssue(issue, onLog);
-      if (!isCancelled?.()) {
-        analyses.set(issue.number, result);
-        completed++;
-        onProgress?.(completed, issues.length);
-      }
-    } catch (e) {
-      // Should be caught inside analyzeIssue, but just in case
-      onLog?.(`Error in worker processing #${issue.number}: ${e}`);
-    }
-
-    // Process next
-    return next();
-  };
-
-  const workers = Array.from({ length: Math.min(CONCURRENCY, issues.length) }, () => next());
-  await Promise.all(workers);
-
-  if (isCancelled?.()) {
-    onLog?.('Analysis cancelled by user.');
-  }
-
-  return analyses;
-}
+export { CONFIG };

--- a/src/lib/api/provider.ts
+++ b/src/lib/api/provider.ts
@@ -1,0 +1,202 @@
+import { ANALYSIS_PROMPT, CONFIG } from '../constants';
+import { callOpenRouter } from './openrouter';
+import { callLocal, resolveLocalConfig } from './local';
+import { AnalysisResultSchema, type AnalysisResult, type Issue, type AIProvider } from '../types';
+import { useAppStore } from '../../store/appStore';
+
+function formatIssueForAnalysis(issue: Issue): string {
+  const parts = [
+    `# Issue #${issue.number}: ${issue.title}`,
+    ``,
+    `**Author**: ${issue.user.login}`,
+    `**Created**: ${issue.created_at}`,
+    `**Updated**: ${issue.updated_at}`,
+    `**Labels**: ${issue.labels.map((l) => l.name).join(', ') || 'none'}`,
+    `**Assignees**: ${issue.assignees.map((a) => a.login).join(', ') || 'none'}`,
+    `**Comment count**: ${issue.comments_count}`,
+    ``,
+    `## Body`,
+    issue.body || '(no description)',
+  ];
+
+  if (issue.comments && issue.comments.length > 0) {
+    parts.push('', '## Comments');
+    for (const comment of issue.comments.slice(0, 15)) {
+      parts.push(
+        ``,
+        `### @${comment.user.login} (${comment.created_at})`,
+        comment.body.slice(0, 500),
+      );
+    }
+  }
+
+  if (issue.timeline && issue.timeline.length > 0) {
+    parts.push('', '## Timeline Events');
+    const relevant = issue.timeline
+      .filter((e) => ['cross-referenced', 'referenced', 'labeled', 'assigned'].includes(e.event))
+      .slice(0, 10);
+    for (const event of relevant) {
+      parts.push(`- ${event.event} by ${event.actor?.login || 'unknown'} at ${event.created_at}`);
+    }
+  }
+
+  return parts.join('\n');
+}
+
+const DEFAULT_ANALYSIS: AnalysisResult = {
+  summary: 'Analysis could not be completed.',
+  status: 'active',
+  progress_estimate: 'not_started',
+  is_actionable_code_change: true,
+  not_mergeable_reason: null,
+  complexity: 3,
+  skills_required: [],
+  newcomer_friendliness: 3,
+  doability_score: 50,
+  analysis_notes: 'Fallback default — AI analysis failed or returned invalid data.',
+};
+
+function parseAnalysisResponse(raw: string): AnalysisResult {
+  try {
+    let jsonStr = raw.trim();
+
+    const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[1].trim();
+    }
+
+    const parsed = JSON.parse(jsonStr);
+    const validated = AnalysisResultSchema.parse(parsed);
+    return validated;
+  } catch {
+    try {
+      const parsed = JSON.parse(raw.trim());
+      return {
+        ...DEFAULT_ANALYSIS,
+        summary: parsed.summary || DEFAULT_ANALYSIS.summary,
+        doability_score:
+          typeof parsed.doability_score === 'number'
+            ? parsed.doability_score
+            : DEFAULT_ANALYSIS.doability_score,
+        complexity:
+          typeof parsed.complexity === 'number' ? parsed.complexity : DEFAULT_ANALYSIS.complexity,
+        skills_required: Array.isArray(parsed.skills_required) ? parsed.skills_required : [],
+        status: parsed.status || DEFAULT_ANALYSIS.status,
+        analysis_notes: parsed.analysis_notes || 'Partially parsed from AI response.',
+      };
+    } catch {
+      return {
+        ...DEFAULT_ANALYSIS,
+        analysis_notes: 'Failed to parse AI response: ' + raw.slice(0, 200),
+      };
+    }
+  }
+}
+
+async function callProvider(
+  provider: AIProvider,
+  systemPrompt: string,
+  userMessage: string,
+): Promise<string> {
+  const state = useAppStore.getState();
+
+  if (provider === 'local') {
+    const config = resolveLocalConfig({
+      endpoint: state.localEndpoint,
+      model: state.localModel,
+      apiKey: state.localApiKey,
+    });
+    if (!config.endpoint || !config.model) {
+      throw new Error(
+        'Local LLM endpoint or model is missing. Please configure it in API settings.',
+      );
+    }
+    return callLocal(systemPrompt, userMessage, config);
+  }
+
+  if (!state.openRouterKey) {
+    throw new Error('OpenRouter API Key is missing. Please configure it.');
+  }
+  return callOpenRouter(systemPrompt, userMessage, state.openRouterKey, CONFIG.DEFAULT_MODEL);
+}
+
+export async function analyzeIssue(
+  issue: Issue,
+  onLog?: (message: string) => void,
+  provider?: AIProvider,
+): Promise<AnalysisResult> {
+  const formatted = formatIssueForAnalysis(issue);
+  const selectedProvider: AIProvider = provider ?? useAppStore.getState().aiProvider;
+  onLog?.(`Analyzing #${issue.number}: ${issue.title.slice(0, 60)}...`);
+
+  let retries = 3;
+  let backoff = 2000;
+
+  while (retries > 0) {
+    try {
+      const raw = await callProvider(selectedProvider, ANALYSIS_PROMPT, formatted);
+      const result = parseAnalysisResponse(raw);
+      onLog?.(
+        `✓ #${issue.number} analyzed — score: ${result.doability_score}/100, status: ${result.status}`,
+      );
+      return result;
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (error.message === 'RATE_LIMITED' && retries > 1) {
+        onLog?.(`⏳ Rate limited. Waiting ${backoff / 1000}s before retry...`);
+        await new Promise((r) => setTimeout(r, backoff));
+        backoff *= 2;
+        retries--;
+        continue;
+      }
+      onLog?.(`✗ Failed to analyze #${issue.number}: ${error.message}`);
+      return { ...DEFAULT_ANALYSIS, analysis_notes: `Error: ${error.message}` };
+    }
+  }
+
+  return DEFAULT_ANALYSIS;
+}
+
+export async function analyzeAllIssues(
+  issues: Issue[],
+  onProgress?: (current: number, total: number) => void,
+  onLog?: (message: string) => void,
+  isCancelled?: () => boolean,
+  provider?: AIProvider,
+): Promise<Map<number, AnalysisResult>> {
+  const analyses = new Map<number, AnalysisResult>();
+  const selectedProvider: AIProvider = provider ?? useAppStore.getState().aiProvider;
+  const concurrency = selectedProvider === 'local' ? 2 : 15;
+  let completed = 0;
+
+  const queue = [...issues];
+
+  const next = async (): Promise<void> => {
+    if (isCancelled?.() || queue.length === 0) return;
+
+    const issue = queue.shift();
+    if (!issue) return;
+
+    try {
+      const result = await analyzeIssue(issue, onLog, selectedProvider);
+      if (!isCancelled?.()) {
+        analyses.set(issue.number, result);
+        completed++;
+        onProgress?.(completed, issues.length);
+      }
+    } catch (e) {
+      onLog?.(`Error in worker processing #${issue.number}: ${e}`);
+    }
+
+    return next();
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, issues.length) }, () => next());
+  await Promise.all(workers);
+
+  if (isCancelled?.()) {
+    onLog?.('Analysis cancelled by user.');
+  }
+
+  return analyses;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,8 @@ export const CONFIG = {
   DEFAULT_MAX_ISSUES: 200,
   MIN_MAX_ISSUES: 10,
   MAX_MAX_ISSUES: 1000,
+  DEFAULT_LOCAL_ENDPOINT: import.meta.env.VITE_LOCAL_ENDPOINT || 'http://localhost:11434/v1',
+  DEFAULT_LOCAL_MODEL: import.meta.env.VITE_LOCAL_MODEL || 'llama3.2',
 } as const;
 
 export const REPO_REGEX = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,22 @@ export interface RankedIssue extends Issue {
   score: number;
 }
 
+// ── AI Provider Types ──────────────────────────────
+
+export type AIProvider = 'openrouter' | 'local';
+
+export interface LocalProviderConfig {
+  endpoint: string;
+  model: string;
+  apiKey?: string;
+}
+
+export interface AIProviderConfig {
+  provider: AIProvider;
+  openRouterKey?: string;
+  local?: LocalProviderConfig;
+}
+
 // ── History Types ───────────────────────────────────
 
 export interface HistoryMetadata {

--- a/src/screens/InputScreen.tsx
+++ b/src/screens/InputScreen.tsx
@@ -16,14 +16,20 @@ import {
   Loader2,
   Sun,
   Moon,
+  Server,
 } from 'lucide-react';
 import { CONFIG } from '../lib/constants';
 import { historyService } from '../lib/history/historyService';
 import { formatTimeAgo } from '../lib/utils/formatters';
+import type { AIProvider } from '../lib/types';
 
 // Storage keys for localStorage
 const STORAGE_KEY_GITHUB = 'isscope_github_token';
 const STORAGE_KEY_OPENROUTER = 'isscope_openrouter_key';
+const STORAGE_KEY_AI_PROVIDER = 'isscope_ai_provider';
+const STORAGE_KEY_LOCAL_ENDPOINT = 'isscope_local_endpoint';
+const STORAGE_KEY_LOCAL_MODEL = 'isscope_local_model';
+const STORAGE_KEY_LOCAL_API_KEY = 'isscope_local_api_key';
 const STORAGE_KEY_MAX_ISSUES = 'isscope_max_issues';
 const STORAGE_KEY_REMEMBER_KEYS = 'isscope_remember_keys';
 
@@ -44,6 +50,12 @@ export function InputScreen() {
     setAnalyses,
     setScreen,
     addLog,
+    aiProvider,
+    setAiProvider,
+    localEndpoint,
+    localModel,
+    localApiKey,
+    setLocalConfig,
   } = useAppStore();
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
@@ -54,6 +66,10 @@ export function InputScreen() {
   // Local state for API key inputs
   const [localGithubToken, setLocalGithubToken] = useState(githubToken);
   const [localOpenRouterKey, setLocalOpenRouterKey] = useState(openRouterKey);
+  const [localProvider, setLocalProvider] = useState<AIProvider>(aiProvider);
+  const [localEndpointInput, setLocalEndpointInput] = useState(localEndpoint);
+  const [localModelInput, setLocalModelInput] = useState(localModel);
+  const [localApiKeyInput, setLocalApiKeyInput] = useState(localApiKey);
   const [localMaxIssues, setLocalMaxIssues] = useState(maxIssues);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
   const [rememberKeys, setRememberKeys] = useState(false);
@@ -67,6 +83,12 @@ export function InputScreen() {
     const storedOpenRouter = shouldRemember
       ? localStorage.getItem(STORAGE_KEY_OPENROUTER) || ''
       : '';
+    const storedProvider = localStorage.getItem(STORAGE_KEY_AI_PROVIDER) as AIProvider | null;
+    const storedEndpoint = localStorage.getItem(STORAGE_KEY_LOCAL_ENDPOINT);
+    const storedModel = localStorage.getItem(STORAGE_KEY_LOCAL_MODEL);
+    const storedLocalApiKey = shouldRemember
+      ? localStorage.getItem(STORAGE_KEY_LOCAL_API_KEY) || ''
+      : '';
     const storedMaxIssues = localStorage.getItem(STORAGE_KEY_MAX_ISSUES);
 
     setRememberKeys(shouldRemember);
@@ -77,6 +99,22 @@ export function InputScreen() {
         openRouterKey: storedOpenRouter,
       });
     }
+
+    if (storedProvider === 'openrouter' || storedProvider === 'local') {
+      setAiProvider(storedProvider);
+      setLocalProvider(storedProvider);
+    }
+
+    if (storedEndpoint || storedModel || storedLocalApiKey) {
+      setLocalConfig({
+        endpoint: storedEndpoint || undefined,
+        model: storedModel || undefined,
+        apiKey: storedLocalApiKey || undefined,
+      });
+    }
+    if (storedEndpoint) setLocalEndpointInput(storedEndpoint);
+    if (storedModel) setLocalModelInput(storedModel);
+    if (storedLocalApiKey) setLocalApiKeyInput(storedLocalApiKey);
 
     if (storedMaxIssues) {
       const parsed = parseInt(storedMaxIssues, 10);
@@ -95,7 +133,7 @@ export function InputScreen() {
         setLocalMaxIssues(parsed);
       }
     }
-  }, [setApiKeys, setMaxIssues]);
+  }, [setApiKeys, setMaxIssues, setAiProvider, setLocalConfig]);
 
   useEffect(() => {
     loadHistory();
@@ -151,13 +189,18 @@ export function InputScreen() {
     if (rememberKeys) {
       localStorage.setItem(STORAGE_KEY_GITHUB, localGithubToken);
       localStorage.setItem(STORAGE_KEY_OPENROUTER, localOpenRouterKey);
+      localStorage.setItem(STORAGE_KEY_LOCAL_API_KEY, localApiKeyInput);
       localStorage.setItem(STORAGE_KEY_REMEMBER_KEYS, 'true');
     } else {
       localStorage.removeItem(STORAGE_KEY_GITHUB);
       localStorage.removeItem(STORAGE_KEY_OPENROUTER);
+      localStorage.removeItem(STORAGE_KEY_LOCAL_API_KEY);
       localStorage.setItem(STORAGE_KEY_REMEMBER_KEYS, 'false');
     }
 
+    localStorage.setItem(STORAGE_KEY_AI_PROVIDER, localProvider);
+    localStorage.setItem(STORAGE_KEY_LOCAL_ENDPOINT, localEndpointInput);
+    localStorage.setItem(STORAGE_KEY_LOCAL_MODEL, localModelInput);
     localStorage.setItem(STORAGE_KEY_MAX_ISSUES, localMaxIssues.toString());
 
     setApiKeys({
@@ -165,6 +208,12 @@ export function InputScreen() {
       openRouterKey: localOpenRouterKey,
     });
 
+    setAiProvider(localProvider);
+    setLocalConfig({
+      endpoint: localEndpointInput,
+      model: localModelInput,
+      apiKey: localApiKeyInput,
+    });
     setMaxIssues(localMaxIssues);
 
     setTimeout(() => {
@@ -646,6 +695,199 @@ export function InputScreen() {
                     />
                   </div>
                 </div>
+
+                <div>
+                  <label
+                    style={{
+                      display: 'block',
+                      fontSize: '12px',
+                      color: 'var(--text-muted)',
+                      marginBottom: '6px',
+                    }}
+                  >
+                    AI Provider
+                  </label>
+                  <div
+                    style={{
+                      display: 'flex',
+                      gap: '6px',
+                      background: 'var(--bg-tertiary)',
+                      border: '1px solid var(--border-subtle)',
+                      borderRadius: '8px',
+                      padding: '4px',
+                    }}
+                  >
+                    {(
+                      [
+                        { value: 'openrouter', label: 'OpenRouter' },
+                        { value: 'local', label: 'Local (Ollama / LMStudio)' },
+                      ] as { value: AIProvider; label: string }[]
+                    ).map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => {
+                          setLocalProvider(opt.value);
+                          setSaveStatus('idle');
+                        }}
+                        style={{
+                          flex: 1,
+                          padding: '8px 10px',
+                          fontSize: '12px',
+                          fontFamily: 'var(--font-mono)',
+                          background: localProvider === opt.value ? 'var(--text)' : 'transparent',
+                          color: localProvider === opt.value ? 'var(--bg)' : 'var(--text-muted)',
+                          border: 'none',
+                          borderRadius: '6px',
+                          cursor: 'pointer',
+                          transition: 'all 0.15s ease',
+                        }}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {localProvider === 'local' && (
+                  <>
+                    <div>
+                      <label
+                        style={{
+                          display: 'block',
+                          fontSize: '12px',
+                          color: 'var(--text-muted)',
+                          marginBottom: '6px',
+                        }}
+                      >
+                        Local Endpoint (Ollama: http://localhost:11434/v1 · LMStudio:
+                        http://localhost:1234/v1)
+                      </label>
+                      <div style={{ position: 'relative' }}>
+                        <input
+                          type="text"
+                          value={localEndpointInput}
+                          onChange={(e) => {
+                            setLocalEndpointInput(e.target.value);
+                            setSaveStatus('idle');
+                          }}
+                          placeholder={CONFIG.DEFAULT_LOCAL_ENDPOINT}
+                          style={{
+                            width: '100%',
+                            padding: '10px 10px 10px 36px',
+                            fontSize: '13px',
+                            background: 'var(--bg-tertiary)',
+                            border: '1px solid var(--border-subtle)',
+                            borderRadius: '8px',
+                            color: 'var(--text)',
+                            fontFamily: 'var(--font-mono)',
+                            outline: 'none',
+                          }}
+                        />
+                        <Server
+                          size={14}
+                          style={{
+                            position: 'absolute',
+                            left: '12px',
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            color: 'var(--text-dim)',
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <label
+                        style={{
+                          display: 'block',
+                          fontSize: '12px',
+                          color: 'var(--text-muted)',
+                          marginBottom: '6px',
+                        }}
+                      >
+                        Local Model Name
+                      </label>
+                      <div style={{ position: 'relative' }}>
+                        <input
+                          type="text"
+                          value={localModelInput}
+                          onChange={(e) => {
+                            setLocalModelInput(e.target.value);
+                            setSaveStatus('idle');
+                          }}
+                          placeholder={CONFIG.DEFAULT_LOCAL_MODEL}
+                          style={{
+                            width: '100%',
+                            padding: '10px 10px 10px 36px',
+                            fontSize: '13px',
+                            background: 'var(--bg-tertiary)',
+                            border: '1px solid var(--border-subtle)',
+                            borderRadius: '8px',
+                            color: 'var(--text)',
+                            fontFamily: 'var(--font-mono)',
+                            outline: 'none',
+                          }}
+                        />
+                        <Server
+                          size={14}
+                          style={{
+                            position: 'absolute',
+                            left: '12px',
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            color: 'var(--text-dim)',
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <label
+                        style={{
+                          display: 'block',
+                          fontSize: '12px',
+                          color: 'var(--text-muted)',
+                          marginBottom: '6px',
+                        }}
+                      >
+                        Local API Key (optional — only if your server requires one)
+                      </label>
+                      <div style={{ position: 'relative' }}>
+                        <input
+                          type="password"
+                          value={localApiKeyInput}
+                          onChange={(e) => {
+                            setLocalApiKeyInput(e.target.value);
+                            setSaveStatus('idle');
+                          }}
+                          placeholder="lm-studio"
+                          style={{
+                            width: '100%',
+                            padding: '10px 10px 10px 36px',
+                            fontSize: '13px',
+                            background: 'var(--bg-tertiary)',
+                            border: '1px solid var(--border-subtle)',
+                            borderRadius: '8px',
+                            color: 'var(--text)',
+                            fontFamily: 'var(--font-mono)',
+                            outline: 'none',
+                          }}
+                        />
+                        <Key
+                          size={14}
+                          style={{
+                            position: 'absolute',
+                            left: '12px',
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            color: 'var(--text-dim)',
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
 
                 <div>
                   <label

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -8,6 +8,7 @@ import type {
   LogType,
   RankedIssue,
   HistoryMetadata,
+  AIProvider,
 } from '../lib/types';
 import { historyService } from '../lib/history/historyService';
 import { CONFIG } from '../lib/constants';
@@ -30,6 +31,14 @@ interface AppState {
   githubToken: string;
   openRouterKey: string;
   setApiKeys: (keys: { githubToken?: string; openRouterKey?: string }) => void;
+
+  // AI Provider
+  aiProvider: AIProvider;
+  setAiProvider: (provider: AIProvider) => void;
+  localEndpoint: string;
+  localModel: string;
+  localApiKey: string;
+  setLocalConfig: (config: { endpoint?: string; model?: string; apiKey?: string }) => void;
 
   // Settings
   maxIssues: number;
@@ -95,6 +104,19 @@ export const useAppStore = create<AppState>((set, get) => ({
   githubToken: '',
   openRouterKey: '',
   setApiKeys: (keys) => set((state) => ({ ...state, ...keys })),
+
+  // AI Provider
+  aiProvider: 'openrouter',
+  setAiProvider: (provider) => set({ aiProvider: provider }),
+  localEndpoint: CONFIG.DEFAULT_LOCAL_ENDPOINT,
+  localModel: CONFIG.DEFAULT_LOCAL_MODEL,
+  localApiKey: '',
+  setLocalConfig: (config) =>
+    set((state) => ({
+      localEndpoint: config.endpoint ?? state.localEndpoint,
+      localModel: config.model ?? state.localModel,
+      localApiKey: config.apiKey ?? state.localApiKey,
+    })),
 
   // Fetching Progress
   fetchProgress: { phase: 'fetching', current: 0, total: 0 },

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_GITHUB_TOKEN: string;
   readonly VITE_OPENROUTER_API_KEY: string;
   readonly VITE_MODEL_NAME: string;
+  readonly VITE_LOCAL_ENDPOINT: string;
+  readonly VITE_LOCAL_MODEL: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Adds a **Local (Ollama / LMStudio)** AI provider option alongside the existing **OpenRouter** cloud provider. Users can now run analysis against any OpenAI-compatible local server (Ollama, LMStudio, etc.) without an API key.
- Refactors the analysis pipeline to be provider-agnostic via a new `src/lib/api/provider.ts` module that dispatches to the right client.
- **Fix:** makes the InputScreen scrollable so the Save Configuration button stays reachable when the panel grows tall (e.g. with the new Local provider fields expanded).

## Why
- Many contributors run open-source LLMs locally (privacy, cost, experimentation). Forcing them through OpenRouter creates friction and excludes offline use.
- Ollama (`http://localhost:11434/v1`) and LMStudio (`http://localhost:1234/v1`) both expose an OpenAI-compatible `/v1/chat/completions` endpoint, so a single client covers both.
- The previous `overflow: hidden` on `ScreenLayout` clipped the InputScreen content; with the extra Local fields the API config panel was taller than the viewport and the Save button was unreachable.

## Changes

**New files**
- `src/lib/api/local.ts` — Local provider client. Hits `${endpoint}/chat/completions`, sends `Authorization: Bearer <key>` only when configured, drops the strict `response_format: json_object` flag (some local backends reject it; the existing parser already handles JSON extraction and partial recovery).
- `src/lib/api/provider.ts` — `analyzeIssue` / `analyzeAllIssues` that dispatch to OpenRouter or Local based on `useAppStore().aiProvider`. Throttles concurrency to 2 for local (vs 15 for cloud) to avoid GPU overload.
- `src/lib/api/local.test.ts` — 11 new tests for the local client and config helpers.

**Modified**
- `src/components/layout/ScreenLayout.tsx` — `overflow: hidden` → `overflow: auto`, `center` → `safe center` so tall centered screens remain scrollable to the top.
- `src/components/layout/ScreenLayout.test.tsx` — updated to assert the new `safe center` alignment.
- `src/lib/api/openrouter.ts` — slimmed down to a pure `callOpenRouter(prompt, user, apiKey, model?, baseUrl?)` function (no more implicit store reads).
- `src/lib/api/openrouter.test.ts` — updated to test the new client signature plus 5 new provider-dispatch tests.
- `src/store/appStore.ts` — adds `aiProvider`, `localEndpoint`, `localModel`, `localApiKey` plus their setters.
- `src/lib/types.ts` — adds `AIProvider`, `LocalProviderConfig`, `AIProviderConfig` types.
- `src/lib/constants.ts` — adds `DEFAULT_LOCAL_ENDPOINT` (`http://localhost:11434/v1`) and `DEFAULT_LOCAL_MODEL` (`llama3.2`), both overridable via `VITE_LOCAL_ENDPOINT` / `VITE_LOCAL_MODEL`.
- `src/hooks/useIssueAnalysis.ts` — imports `analyzeAllIssues` from `./api/provider`; logs `Provider: openrouter (<model>)` or `Provider: local (<endpoint> — <model>)` instead of just the model.
- `src/screens/InputScreen.tsx` — adds an AI provider toggle (OpenRouter / Local) in the API config panel. When Local is selected, three extra fields appear: endpoint, model, and an optional API key (with LMStudio's `lm-studio` placeholder). All settings persist to `localStorage` alongside the existing "remember keys" flow.
- `vite-env.d.ts` — declares the new env var types.
- `.env.example` — documents `VITE_LOCAL_ENDPOINT` and `VITE_LOCAL_MODEL`.

## Usage
1. Start Ollama (`ollama serve`, defaults to `http://localhost:11434/v1`) or LMStudio and load a model.
2. Open the app → "Configure API Keys" → choose **Local (Ollama / LMStudio)**.
3. Set the endpoint (Ollama default pre-filled; LMStudio users swap to `http://localhost:1234/v1`) and the model name (default `llama3.2`).
4. Save and start the analysis — the log will show `Provider: local (http://localhost:11434/v1 — llama3.2)`.

## Test results
- `bun run test --run` → **170 passed (170)** across 29 files (was 151 before this PR, +19 new tests).
- `bun run format:check` ✓
- `bunx eslint .` ✓ (0 errors; +2 pre-existing-style `no-explicit-any` warnings in the new test files)
- `bun run typecheck` ✓
- `bun run build` ✓

## Notes
- AI assistance: this PR was prepared with opencode (model: opencode-go/minimax-m3).
- No behavior change for existing OpenRouter users — the default provider is still `openrouter`.
- The local client deliberately omits the OpenRouter-specific `HTTP-Referer` and `X-Title` headers, which would leak the app's URL/title to a local server.